### PR TITLE
Propose unify & optimize u32u8a and rename it to toBytes

### DIFF
--- a/assembly/index.ts
+++ b/assembly/index.ts
@@ -6,11 +6,10 @@ import {
   setRentAllowance,
   setScratchBuffer,
   setStorage,
-  u32ToU8a
+  toBytes
 } from './lib';
 
-const COUNTER_KEY: Uint8Array = new Uint8Array(32);
-COUNTER_KEY.fill(1);
+const COUNTER_KEY = (new Uint8Array(32)).fill(1);
 
 enum Action {
   Inc,
@@ -28,9 +27,9 @@ function handle(input: Uint8Array): Uint8Array { // vec<u8>
   // Get action from first byte of the input U8A
   switch (input[0]) {
     case Action.Inc:
-      // read 4 bytes (u32) from storageBuffer with offset 1 
+      // read 4 bytes (u32) from storageBuffer with offset 1
       const by: u32 = load<u32>(input.dataStart, 1);
-      const newCounter: Uint8Array = u32ToU8a(counterValue + by);
+      const newCounter = toBytes(counterValue + by);
       setStorage(COUNTER_KEY, newCounter)
       break;
     case Action.Get:

--- a/assembly/index.ts
+++ b/assembly/index.ts
@@ -19,18 +19,18 @@ enum Action {
 
 // class Action with parameter value & method incBy
 function handle(input: Uint8Array): Uint8Array { // vec<u8>
-  const value : Uint8Array = new Uint8Array(0);
+  const value = new Uint8Array(0);
   const counter: Uint8Array = getStorage(COUNTER_KEY);
-  const dataCounter: DataView = new DataView(counter.buffer);
+  const dataCounter = new DataView(counter.buffer);
   const counterValue: u32 = dataCounter.byteLength ? dataCounter.getUint32(0, true) : 0;
 
   // Get action from first byte of the input U8A
   switch (input[0]) {
     case Action.Inc:
       // read 4 bytes (u32) from storageBuffer with offset 1
-      const by: u32 = load<u32>(input.dataStart, 1);
+      const by = load<u32>(input.dataStart, 1);
       const newCounter = toBytes(counterValue + by);
-      setStorage(COUNTER_KEY, newCounter)
+      setStorage(COUNTER_KEY, newCounter);
       break;
     case Action.Get:
       // return the counter from storage
@@ -39,7 +39,7 @@ function handle(input: Uint8Array): Uint8Array { // vec<u8>
       break;
     case Action.SelfEvict:
       const allowance = u128.from<u32>(0);
-      setRentAllowance(allowance)
+      setRentAllowance(allowance);
       break;
   }
   return value;
@@ -56,5 +56,5 @@ export function call(): u32 {
 
 // deploy a new instance of the contract
 export function deploy(): u32 {
-  return 0
+  return 0;
 }

--- a/assembly/lib.ts
+++ b/assembly/lib.ts
@@ -14,13 +14,14 @@ enum Storage {
 }
 
 export function toBytes<T>(num: T, le = true): Uint8Array {
+  const arr = new Uint8Array(sizeof<T>());
   // accept only integers and booleans
   if (isInteger<T>()) {
-    const arr = new Uint8Array(sizeof<T>());
     store<T>(arr.dataStart, le ? num : bswap(num));
     return arr;
   }
   assert(false);
+  return arr;
 }
 
 

--- a/assembly/lib.ts
+++ b/assembly/lib.ts
@@ -14,14 +14,13 @@ enum Storage {
 }
 
 export function toBytes<T>(num: T, le = true): Uint8Array {
-  const arr = new Uint8Array(sizeof<T>());
   // accept only integers and booleans
   if (isInteger<T>()) {
+    const arr = new Uint8Array(sizeof<T>());
     store<T>(arr.dataStart, le ? num : bswap(num));
     return arr;
   }
   assert(false);
-  return arr;
 }
 
 

--- a/assembly/lib.ts
+++ b/assembly/lib.ts
@@ -8,9 +8,9 @@ import {
   ext_set_storage
 } from './env';
 
-enum Storage {
-  HAS_VALUE,
-  NO_VALUE
+export enum StorageResult {
+  Value,
+  None
 }
 
 export function toBytes<T>(num: T, le = true): Uint8Array {
@@ -27,7 +27,7 @@ export function toBytes<T>(num: T, le = true): Uint8Array {
 export function setStorage(key: Uint8Array, value: Uint8Array): void {
   const pointer = value ? value.dataStart : 0;
   const length = value ? value.length : 0;
-  const valueNonNull = value ? 1 : 0;
+  const valueNonNull = i32(value != 0);
 
   ext_set_storage(key.dataStart, valueNonNull, pointer, length);
 }
@@ -43,11 +43,11 @@ export function getStorage(key: Uint8Array): Uint8Array {
   let value = new Uint8Array(0);
 
   // if value is found
-  if (result === Storage.HAS_VALUE) {
+  if (result === StorageResult.Value) {
     // // getting size of scratch buffer to allocate the buffer of corresponding size to fit the contents of the scratch buffer
     const size: u32 = ext_scratch_size();
     // if value is not null or not an empty array
-    if (size >  0) {
+    if (size > 0) {
       // create empty array (Vec in Rust)
       value = new Uint8Array(size);
       // call
@@ -75,6 +75,6 @@ export function setScratchBuffer(data: Uint8Array): void {
 }
 
 export function setRentAllowance(value: u128): void {
-  const valueBuffer: Uint8Array = value.toUint8Array();
+  const valueBuffer = value.toUint8Array();
   ext_set_rent_allowance(valueBuffer.dataStart, valueBuffer.length);
 }


### PR DESCRIPTION
Use less idiomatic JS/TS but more performant and flexible approach.
`toBytes` (convert number to Uint8Array) support integers / unsigned integers with any size up to 64-bit and reject floats for example. Also support big endian and little endian.